### PR TITLE
Add bulk delete mode for transactions with confirmation flow

### DIFF
--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -8,6 +8,9 @@ import MassImportModal from "../components/Modals/MassImportModal.jsx";
 export default function Transactions() {
   const { user, authChecked } = useUser();
   const [showImportModal, setShowImportModal] = useState(false);
+  const [bulkDeleteMode, setBulkDeleteMode] = useState(false);
+  const [selectedTransactionIds, setSelectedTransactionIds] = useState([]);
+  const [deleteError, setDeleteError] = useState(null);
 
   const transactions = useTransaction((state) => state.transactions);
   const loading = useTransaction((state) => state.loading);
@@ -45,6 +48,11 @@ export default function Transactions() {
     });
   }, [transactions, typeFilter]);
 
+  const selectedOnScreenCount = useMemo(
+    () => filtered.filter((tx) => selectedTransactionIds.includes(tx.id)).length,
+    [filtered, selectedTransactionIds],
+  );
+
   // Alkalmaz gomb logika: csak ha változott, akkor állítjuk be az aktív szűrőt
   const applyFilter = () => {
     setTypeFilter(pendingFilter);
@@ -54,6 +62,47 @@ export default function Transactions() {
   const clearFilter = () => {
     setPendingFilter("all");
     setTypeFilter("all");
+  };
+
+  const toggleBulkDeleteMode = () => {
+    setDeleteError(null);
+    setSelectedTransactionIds([]);
+    setBulkDeleteMode((prev) => !prev);
+  };
+
+  const toggleTransactionSelection = (id) => {
+    if (id === undefined || id === null) return;
+    setDeleteError(null);
+    setSelectedTransactionIds((prev) =>
+      prev.includes(id) ? prev.filter((txId) => txId !== id) : [...prev, id],
+    );
+  };
+
+  const cancelBulkDelete = () => {
+    setBulkDeleteMode(false);
+    setSelectedTransactionIds([]);
+    setDeleteError(null);
+  };
+
+  const handleBulkDelete = async () => {
+    if (!selectedTransactionIds.length) {
+      setDeleteError("Válassz ki legalább egy tranzakciót.");
+      return;
+    }
+
+    const confirmed = window.confirm(
+      `Biztosan törölni szeretnél ${selectedTransactionIds.length} tranzakciót? Ez a művelet nem visszavonható.`,
+    );
+
+    if (!confirmed) return;
+
+    try {
+      const { massDeleteTransactions } = useTransaction.getState();
+      await massDeleteTransactions(selectedTransactionIds, user);
+      cancelBulkDelete();
+    } catch (err) {
+      setDeleteError(err?.message || "A tömeges törlés sikertelen.");
+    }
   };
 
   if (loading) return <div>Betöltés...</div>;
@@ -143,10 +192,43 @@ export default function Transactions() {
             Töröl
           </button>
 
+          {!bulkDeleteMode ? (
+            <button
+              onClick={toggleBulkDeleteMode}
+              className="bulkDeleteToggleButton"
+              title="Tömeges törlés"
+              aria-label="Tömeges törlés mód"
+            >
+              Tömeges törlés
+            </button>
+          ) : (
+            <div className="bulkDeleteActions">
+              <span className="bulkDeleteCount">Kijelölve: {selectedOnScreenCount}</span>
+              <button
+                onClick={cancelBulkDelete}
+                className="bulkDeleteCancelButton"
+                title="Tömeges törlés megszakítása"
+                aria-label="Tömeges törlés megszakítása"
+              >
+                Mégse
+              </button>
+              <button
+                onClick={handleBulkDelete}
+                className="bulkDeleteConfirmButton"
+                title="Kijelöltek törlése"
+                aria-label="Kijelöltek törlése"
+              >
+                Törlés véglegesítése
+              </button>
+            </div>
+          )}
+
           <div className="resultCount" aria-live="polite">
             Találatok: <strong>{filtered.length}</strong>
           </div>
         </div>
+
+        {deleteError && <p className="bulkDeleteError">{deleteError}</p>}
 
         {/* Megmutatjuk melyik szűrő van épp alkalmazva */}
         <div className="appliedInfo">
@@ -174,6 +256,7 @@ export default function Transactions() {
         >
           <thead>
             <tr>
+              {bulkDeleteMode && <th scope="col">Kijelölés</th>}
               <th scope="col">Dátum</th>
               <th scope="col">Összeg</th>
               <th scope="col">Leírás</th>
@@ -201,8 +284,21 @@ export default function Transactions() {
                 dateStr = tx.date || "-";
               }
 
+              const isSelected = selectedTransactionIds.includes(tx.id);
+
               return (
                 <tr key={tx.id || idx}>
+                  {bulkDeleteMode && (
+                    <td>
+                      <input
+                        type="checkbox"
+                        checked={Boolean(isSelected)}
+                        disabled={!tx.id}
+                        onChange={() => toggleTransactionSelection(tx.id)}
+                        aria-label={`Tranzakció kijelölése: ${tx.description || tx.id || idx}`}
+                      />
+                    </td>
+                  )}
                   <td>{dateStr}</td>
                   <td>{tx.amount ?? "-"}</td>
                   <td title={tx.description || "-"}>{tx.description || "-"}</td>

--- a/src/pages/styles/Transactions.css
+++ b/src/pages/styles/Transactions.css
@@ -114,6 +114,49 @@
     font-weight: 600;
 }
 
+.bulkDeleteToggleButton,
+.bulkDeleteCancelButton,
+.bulkDeleteConfirmButton {
+    padding: 8px 12px;
+    border-radius: 8px;
+    border: 1px solid transparent;
+    cursor: pointer;
+    font-weight: 600;
+}
+
+.bulkDeleteToggleButton {
+    background: #7c3aed;
+    color: #fff;
+}
+
+.bulkDeleteActions {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.bulkDeleteCount {
+    font-size: 0.9rem;
+    font-weight: 600;
+}
+
+.bulkDeleteCancelButton {
+    background: #fff;
+    color: #111;
+    border-color: #d1d5db;
+}
+
+.bulkDeleteConfirmButton {
+    background: #dc2626;
+    color: #fff;
+}
+
+.bulkDeleteError {
+    color: #b91c1c;
+    margin: 8px 0 0;
+    font-size: 0.9rem;
+}
+
 /* Alkalmazott szűrő infó (kis text) */
 .appliedInfo {
     margin-top: 8px;
@@ -232,4 +275,3 @@
 .importButton:active {
     transform: translateY(1px);
 }
-

--- a/src/stores/useTransaction.js
+++ b/src/stores/useTransaction.js
@@ -116,6 +116,53 @@ export const useTransaction = create(
         }
       },
 
+      massDeleteTransactions: async (transactionIds, user) => {
+        if (!user || typeof user.getIdToken !== "function") {
+          const msg = "Nincs bejelentkezett user.";
+          set({ error: msg });
+          throw new Error(msg);
+        }
+
+        if (!Array.isArray(transactionIds) || transactionIds.length === 0) {
+          throw new Error("Nincs kiválasztott tranzakció a törléshez.");
+        }
+
+        if (get().loading) {
+          throw new Error("Már folyamatban van egy művelet.");
+        }
+
+        set({ loading: true, error: null });
+
+        try {
+          const token = await user.getIdToken();
+          const res = await fetch("/api/transactions/mass_delete", {
+            method: "DELETE",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({ transaction_ids: transactionIds }),
+          });
+
+          if (!res.ok) {
+            const text = await res.text().catch(() => "");
+            throw new Error(`Tömeges törlés sikertelen: ${res.status} ${text}`);
+          }
+
+          set((state) => ({
+            transactions: state.transactions.filter(
+              (tx) => !transactionIds.includes(tx.id),
+            ),
+            loading: false,
+          }));
+
+          return true;
+        } catch (err) {
+          set({ error: err.message || "Tömeges törlés hiba", loading: false });
+          throw err;
+        }
+      },
+
       resetTransactions: () =>
         set({ transactions: [], loading: false, error: null, fetched: false }),
     }),


### PR DESCRIPTION
### Motivation
- Provide a user-facing bulk delete feature in the Transactions tab because there was no mass-delete functionality in the store or UI.
- Ensure safe UX by allowing selection, cancelation, and an explicit confirmation before sending a delete request to the backend.

### Description
- Added a new store action `massDeleteTransactions(transactionIds, user)` that calls `DELETE /api/transactions/mass_delete` with `{ transaction_ids }`, validates auth, and removes deleted items from local `transactions` on success.
- Implemented a bulk-delete UI mode in `src/pages/Transactions.jsx` with a `Tömeges törlés` toggle, per-row checkboxes, selection tracking, `Mégse` cancel, and a confirmation prompt before invoking the store action.
- Added error handling UI (`bulkDeleteError`) and controls for selected count, cancel, and finalize actions in the Transactions page.
- Added styles for bulk-delete controls and feedback in `src/pages/styles/Transactions.css`.

### Testing
- Ran linting with `npx eslint src/pages/Transactions.jsx src/stores/useTransaction.js src/pages/styles/Transactions.css`, which completed with no errors (only a css warning reported). ✅
- Attempted a production build with `npm run build`, which failed due to pre-existing unresolved imports in unrelated files (`src/pages/Statistics.jsx` and `src/components/Insights.jsx`), not caused by these changes. ⚠️
- Launched the dev server and captured an automated Playwright screenshot of the updated Transactions page at `/transactions` to validate the UI changes (screenshot artifact saved). ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a599a876d08328982b04d0bf0517b4)