### PR TITLE
Add bulk delete for transactions, normalize IDs, and update UI/CSS

### DIFF
--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -5,18 +5,24 @@ import { useUser } from "../stores/useUser";
 import "./styles/Transactions.css";
 import MassImportModal from "../components/Modals/MassImportModal.jsx";
 
+const getTransactionId = (tx) =>
+  tx?.id ?? tx?.transaction_id ?? tx?.tran_id ?? tx?._id ?? null;
+
+const normalizeTransactionId = (id) => (id === null || id === undefined ? null : String(id));
+
 export default function Transactions() {
   const { user, authChecked } = useUser();
   const [showImportModal, setShowImportModal] = useState(false);
+  const [bulkDeleteMode, setBulkDeleteMode] = useState(false);
+  const [selectedTransactionIds, setSelectedTransactionIds] = useState([]);
+  const [deleteError, setDeleteError] = useState(null);
 
   const transactions = useTransaction((state) => state.transactions);
   const loading = useTransaction((state) => state.loading);
   const error = useTransaction((state) => state.error);
   const fetched = useTransaction((state) => state.fetched);
 
-  // --- Aktív szűrő amely ténylegesen hat a listára
   const [typeFilter, setTypeFilter] = useState("all");
-  // --- Ideiglenes választás a selectben (amíg meg nem nyomod az "Alkalmaz" gombot)
   const [pendingFilter, setPendingFilter] = useState("all");
 
   useEffect(() => {
@@ -29,10 +35,8 @@ export default function Transactions() {
   const normalizeType = (val) => {
     if (val === null || val === undefined) return "";
     const t = String(val).trim().toLowerCase();
-    if (["kiadás", "outgoing", "expense", "expenses"].includes(t))
-      return "outgoing";
-    if (["bevétel", "income", "revenue", "incomes", "incoming"].includes(t))
-      return "income";
+    if (["kiadás", "outgoing", "expense", "expenses"].includes(t)) return "outgoing";
+    if (["bevétel", "income", "revenue", "incomes", "incoming"].includes(t)) return "income";
     return t;
   };
 
@@ -45,20 +49,65 @@ export default function Transactions() {
     });
   }, [transactions, typeFilter]);
 
-  // Alkalmaz gomb logika: csak ha változott, akkor állítjuk be az aktív szűrőt
-  const applyFilter = () => {
-    setTypeFilter(pendingFilter);
-  };
+  const selectedOnScreenCount = useMemo(() => {
+    if (!filtered.length || !selectedTransactionIds.length) return 0;
+    return filtered.filter((tx) => {
+      const id = normalizeTransactionId(getTransactionId(tx));
+      return id && selectedTransactionIds.includes(id);
+    }).length;
+  }, [filtered, selectedTransactionIds]);
 
-  // Gyors reset (visszaállítja a pending-et és az aktívot is)
+  const applyFilter = () => setTypeFilter(pendingFilter);
+
   const clearFilter = () => {
     setPendingFilter("all");
     setTypeFilter("all");
   };
 
+  const toggleBulkDeleteMode = () => {
+    setDeleteError(null);
+    setSelectedTransactionIds([]);
+    setBulkDeleteMode((prev) => !prev);
+  };
+
+  const toggleTransactionSelection = (rawId) => {
+    const id = normalizeTransactionId(rawId);
+    if (!id) return;
+
+    setDeleteError(null);
+    setSelectedTransactionIds((prev) =>
+      prev.includes(id) ? prev.filter((txId) => txId !== id) : [...prev, id],
+    );
+  };
+
+  const cancelBulkDelete = () => {
+    setBulkDeleteMode(false);
+    setSelectedTransactionIds([]);
+    setDeleteError(null);
+  };
+
+  const handleBulkDelete = async () => {
+    if (!selectedTransactionIds.length) {
+      setDeleteError("Válassz ki legalább egy tranzakciót.");
+      return;
+    }
+
+    const confirmed = window.confirm(
+      `Biztosan törölni szeretnél ${selectedTransactionIds.length} tranzakciót? Ez a művelet nem visszavonható.`,
+    );
+    if (!confirmed) return;
+
+    try {
+      const { massDeleteTransactions } = useTransaction.getState();
+      await massDeleteTransactions(selectedTransactionIds, user);
+      cancelBulkDelete();
+    } catch (err) {
+      setDeleteError(err?.message || "A tömeges törlés sikertelen.");
+    }
+  };
+
   if (loading) return <div>Betöltés...</div>;
-  // If loading, show loader. Otherwise, when there are no transactions show the
-  // original no-transactions card (and surface any store error inside it).
+
   if (!transactions || transactions.length === 0)
     return (
       <div className="transactionsWrapper noTransactions">
@@ -74,19 +123,13 @@ export default function Transactions() {
           user={user}
         />
         <div className="noTransactionsCard">
-          {/* prefer showing the friendly card; if there's an error show it inline */}
           {error ? (
-            <p style={{ color: "#b91c1c", marginBottom: 12 }}>
-              {String(error)}
-            </p>
+            <p style={{ color: "#b91c1c", marginBottom: 12 }}>{String(error)}</p>
           ) : (
             <p>Nincsenek tranzakciók.</p>
           )}
 
-          <button
-            className="importButton"
-            onClick={() => setShowImportModal(true)}
-          >
+          <button className="importButton" onClick={() => setShowImportModal(true)}>
             Kiadások importálása OTP-ből
           </button>
         </div>
@@ -106,7 +149,7 @@ export default function Transactions() {
         isOpen={showImportModal}
         user={user}
       />
-      {/* --- Szűrő doboz (kártya) */}
+
       <div className="filterBox" role="region" aria-label="Tranzakció szűrő">
         <div className="filterRow">
           <label htmlFor="typeFilter" className="filterLabel">
@@ -125,55 +168,53 @@ export default function Transactions() {
             <option value="income">Bevétel</option>
           </select>
 
-          <button
-            onClick={applyFilter}
-            className="filterApplyButton"
-            title="Szűrő alkalmazása"
-            aria-label="Szűrő alkalmazása"
-          >
+          <button onClick={applyFilter} className="filterApplyButton" aria-label="Szűrő alkalmazása">
             Alkalmaz
           </button>
 
-          <button
-            onClick={clearFilter}
-            className="filterClearButton"
-            title="Szűrő törlése"
-            aria-label="Szűrő törlése"
-          >
+          <button onClick={clearFilter} className="filterClearButton" aria-label="Szűrő törlése">
             Töröl
           </button>
+
+          {!bulkDeleteMode ? (
+            <button
+              onClick={toggleBulkDeleteMode}
+              className="bulkDeleteToggleButton"
+              aria-label="Tömeges törlés mód"
+            >
+              Tömeges törlés
+            </button>
+          ) : (
+            <div className="bulkDeleteActions">
+              <span className="bulkDeleteCount">Kijelölve: {selectedOnScreenCount}</span>
+              <button onClick={cancelBulkDelete} className="bulkDeleteCancelButton">
+                Mégse
+              </button>
+              <button onClick={handleBulkDelete} className="bulkDeleteConfirmButton">
+                Törlés véglegesítése
+              </button>
+            </div>
+          )}
 
           <div className="resultCount" aria-live="polite">
             Találatok: <strong>{filtered.length}</strong>
           </div>
         </div>
 
-        {/* Megmutatjuk melyik szűrő van épp alkalmazva */}
-        <div className="appliedInfo">
-          {typeFilter !== "all" && (
-            <div className="appliedInfo">
-              Aktív szűrő:{" "}
-              <strong>
-                {typeFilter === "outgoing"
-                  ? "Kiadás"
-                  : typeFilter === "income"
-                    ? "Bevétel"
-                    : "Ismeretlen"}
-              </strong>
-            </div>
-          )}
-        </div>
+        {deleteError && <p className="bulkDeleteError">{deleteError}</p>}
+
+        {typeFilter !== "all" && (
+          <div className="activeFilterInfo">
+            Aktív szűrő: <strong>{typeFilter === "outgoing" ? "Kiadás" : "Bevétel"}</strong>
+          </div>
+        )}
       </div>
 
-      {/* --- Táblázat konténerrel (lekerekített, fehér háttér) */}
       <div className="tableContainer">
-        <table
-          className="transactionsTable"
-          role="table"
-          aria-label="Tranzakciók"
-        >
+        <table className="transactionsTable" role="table" aria-label="Tranzakciók">
           <thead>
             <tr>
+              {bulkDeleteMode && <th scope="col">Kijelölés</th>}
               <th scope="col">Dátum</th>
               <th scope="col">Összeg</th>
               <th scope="col">Leírás</th>
@@ -183,26 +224,34 @@ export default function Transactions() {
           </thead>
           <tbody>
             {filtered.map((tx, idx) => {
+              const transactionId = getTransactionId(tx);
+              const normalizedId = normalizeTransactionId(transactionId);
               const rawType = tx.tran_type ?? tx.type ?? "";
               const norm = normalizeType(rawType);
-              const displayType =
-                norm === "outgoing"
-                  ? "Kiadás"
-                  : norm === "income"
-                    ? "Bevétel"
-                    : rawType || "-";
+              const displayType = norm === "outgoing" ? "Kiadás" : norm === "income" ? "Bevétel" : rawType || "-";
 
               let dateStr;
               try {
-                dateStr = tx.date
-                  ? new Date(tx.date).toLocaleDateString()
-                  : "-";
+                dateStr = tx.date ? new Date(tx.date).toLocaleDateString() : "-";
               } catch {
                 dateStr = tx.date || "-";
               }
 
+              const isSelected = normalizedId ? selectedTransactionIds.includes(normalizedId) : false;
+
               return (
-                <tr key={tx.id || idx}>
+                <tr key={normalizedId || `${tx.description || "tx"}-${idx}`}>
+                  {bulkDeleteMode && (
+                    <td>
+                      <input
+                        type="checkbox"
+                        checked={isSelected}
+                        disabled={!normalizedId}
+                        onChange={() => toggleTransactionSelection(normalizedId)}
+                        aria-label={`Tranzakció kijelölése: ${tx.description || normalizedId || idx}`}
+                      />
+                    </td>
+                  )}
                   <td>{dateStr}</td>
                   <td>{tx.amount ?? "-"}</td>
                   <td title={tx.description || "-"}>{tx.description || "-"}</td>

--- a/src/pages/styles/Transactions.css
+++ b/src/pages/styles/Transactions.css
@@ -1,44 +1,35 @@
-/* --- Frissített src/components/styles/Transactions.css --- */
-
-/* wrapper az egészhez (középre igazít, responsive) */
 .transactionsWrapper {
     width: 70%;
     max-width: 1100px;
     margin: 18px auto;
     padding: 6px;
     box-sizing: border-box;
-    /* Biztosítjuk, hogy a wrapper világos hátterű legyen (felülírja a dark mode-t) */
     background-color: transparent;
 }
 
-/* container ami a border-radius-ot és a border-t kezeli */
 .tableContainer {
     border-radius: 8px;
     overflow: hidden;
     border: 1px solid #ddd;
-    background: #ffffff; /* FEHÉR háttér: így nem lesz fekete alapon fekete szöveg */
-    color: lightblue; /* alapértelmezett szöveg sötét */
-    /* javaslat: enyhe árnyék, ha szeretnéd (törölhető) */
+    background: #ffffff;
+    color: lightblue;
     box-shadow: 0 1px 4px rgba(16, 24, 40, 0.03);
-    /* Segít a böngésző színrendszerének kezelésében */
     color-scheme: light;
 }
 
-/* maga a tábla */
 .transactionsTable {
     width: 100%;
     border-collapse: separate;
     border-spacing: 0;
     table-layout: fixed;
     font-family: inherit;
-    background: transparent; /* a konténer adja a fehér hátteret */
-    color: inherit; /* örökli a .tableContainer színét */
+    background: transparent;
+    color: inherit;
 }
 
-/* fejlécek - világos fejlécek, sötét betű */
 .transactionsTable th {
-    background-color: #999DA0; /* páratlan sorok: fehér */
-    color: #111111; /* sötét, jól látható */
+    background-color: #999DA0;
+    color: #111111;
     padding: 12px 15px;
     text-align: left;
     font-weight: 600;
@@ -47,7 +38,6 @@
     border-bottom: 1px solid rgba(0, 0, 0, 0.08);
 }
 
-/* sejtszintű stílusok */
 .transactionsTable td {
     padding: 10px 15px;
     border-bottom: 1px solid #eee;
@@ -57,84 +47,33 @@
     text-overflow: ellipsis;
 }
 
-/* alternáló sorok (lágy, olvasható) */
 .transactionsTable tbody tr:nth-child(odd) {
     background-color: #222021;
     color: white;
 }
 
 .transactionsTable tbody tr:nth-child(even) {
-    background-color: #999DA0; /* páratlan sorok: fehér */
+    background-color: #999DA0;
     color: black;
 }
 
-/* Szűrő doboz (kártya) */
 .filterBox {
     border: 1px solid #e3e7ee;
     padding: 12px;
     border-radius: 10px;
     box-shadow: 0 6px 18px rgba(16, 24, 40, 0.04);
     margin-bottom: 14px;
-    background-color: #999DA0; /* páratlan sorok: fehér */
+    background-color: #999DA0;
     color: black;
 }
 
-/* Eddigi .filterRow marad, de hozzáadunk gombokat */
 .filterRow {
     display: flex;
     gap: 10px;
     align-items: center;
     flex-wrap: wrap;
-}
-
-/* Alkalmaz gomb */
-.filterApplyButton {
-    padding: 8px 12px;
-    border-radius: 8px;
-    border: none;
-    background: #3b82f6; /* kék, figyelemfelkeltő */
-    color: #fff;
-    cursor: pointer;
-    font-weight: 600;
-    transition: transform 80ms ease;
-}
-
-.filterApplyButton:active {
-    transform: translateY(1px);
-}
-
-/* Töröl gomb (kisebb, semleges) */
-.filterClearButton {
-    padding: 8px 12px;
-    border-radius: 8px;
-    border: 1px solid #d1d5db;
-    background: #fff;
-    color: #111;
-    cursor: pointer;
-    font-weight: 600;
-}
-
-/* Alkalmazott szűrő infó (kis text) */
-.appliedInfo {
-    margin-top: 8px;
-    color: #444;
-    font-size: 0.95rem;
-}
-
-
-/* Hover ELTÁVOLÍTVA (kérésed szerint) */
-/* korábbi: .transactionsTable tbody tr:hover { background-color: #f1f7ff; } */
-/* Nincs hover szabály többé */
-
-/* --- Szűrősáv stílusok --- */
-.filterRow {
-    display: flex;
-    gap: 10px;
-    align-items: center;
     margin-bottom: 12px;
     width: 100%;
-
-
 }
 
 .filterLabel {
@@ -152,6 +91,21 @@
     color: #111;
 }
 
+.filterApplyButton {
+    padding: 8px 12px;
+    border-radius: 8px;
+    border: none;
+    background: #3b82f6;
+    color: #fff;
+    cursor: pointer;
+    font-weight: 600;
+    transition: transform 80ms ease;
+}
+
+.filterApplyButton:active {
+    transform: translateY(1px);
+}
+
 .filterClearButton {
     padding: 8px 10px;
     border-radius: 6px;
@@ -160,6 +114,56 @@
     cursor: pointer;
     font-size: 0.95rem;
     color: #111;
+    font-weight: 600;
+}
+
+.bulkDeleteToggleButton,
+.bulkDeleteCancelButton,
+.bulkDeleteConfirmButton {
+    padding: 8px 12px;
+    border-radius: 8px;
+    border: 1px solid transparent;
+    cursor: pointer;
+    font-weight: 600;
+}
+
+.bulkDeleteToggleButton {
+    background: #7c3aed;
+    color: #fff;
+}
+
+.bulkDeleteActions {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.bulkDeleteCount {
+    font-size: 0.9rem;
+    font-weight: 600;
+}
+
+.bulkDeleteCancelButton {
+    background: #fff;
+    color: #111;
+    border-color: #d1d5db;
+}
+
+.bulkDeleteConfirmButton {
+    background: #dc2626;
+    color: #fff;
+}
+
+.bulkDeleteError {
+    color: #b91c1c;
+    margin: 8px 0 0;
+    font-size: 0.9rem;
+}
+
+.activeFilterInfo {
+    margin-top: 8px;
+    color: #444;
+    font-size: 0.95rem;
 }
 
 .resultCount {
@@ -171,7 +175,6 @@
     gap: 6px;
 }
 
-/* kis reszponzivitás mobilra */
 @media (max-width: 880px) {
     .transactionsWrapper {
         width: 92%;
@@ -182,7 +185,8 @@
         font-size: 0.9rem;
     }
 
-    .transactionsTable th, .transactionsTable td {
+    .transactionsTable th,
+    .transactionsTable td {
         padding: 8px 10px;
         font-size: 0.9rem;
     }
@@ -190,7 +194,7 @@
 
 .noTransactionsCard {
     display: flex;
-    flex-direction: column; /* ez a kulcs! */
+    flex-direction: column;
     justify-content: center;
     align-items: center;
     border-radius: 12px;
@@ -210,13 +214,12 @@
     margin: 0;
 }
 
-/* Gomb stílusa a noTransactionsCard alatt */
 .importButton {
     margin-top: 20px;
     padding: 12px 24px;
     border: none;
     border-radius: 8px;
-    background-color: #3b82f6; /* kék */
+    background-color: #3b82f6;
     color: white;
     font-size: 1rem;
     font-weight: 600;
@@ -225,11 +228,10 @@
 }
 
 .importButton:hover {
-    background-color: #2563eb; /* sötétebb kék hover */
+    background-color: #2563eb;
     transform: translateY(-2px);
 }
 
 .importButton:active {
     transform: translateY(1px);
 }
-

--- a/src/stores/useTransaction.js
+++ b/src/stores/useTransaction.js
@@ -116,6 +116,55 @@ export const useTransaction = create(
         }
       },
 
+      massDeleteTransactions: async (transactionIds, user) => {
+        if (!user || typeof user.getIdToken !== "function") {
+          const msg = "Nincs bejelentkezett user.";
+          set({ error: msg });
+          throw new Error(msg);
+        }
+
+        if (!Array.isArray(transactionIds) || transactionIds.length === 0) {
+          throw new Error("Nincs kiválasztott tranzakció a törléshez.");
+        }
+
+        if (get().loading) {
+          throw new Error("Már folyamatban van egy művelet.");
+        }
+
+        set({ loading: true, error: null });
+
+        try {
+          const token = await user.getIdToken();
+          const res = await fetch("/api/transactions/mass_delete", {
+            method: "DELETE",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({ transaction_ids: transactionIds }),
+          });
+
+          if (!res.ok) {
+            const text = await res.text().catch(() => "");
+            throw new Error(`Tömeges törlés sikertelen: ${res.status} ${text}`);
+          }
+
+          const idSet = new Set(transactionIds.map((id) => String(id)));
+          set((state) => ({
+            transactions: state.transactions.filter((tx) => {
+              const txId = tx?.id ?? tx?.transaction_id ?? tx?.tran_id ?? tx?._id;
+              return !idSet.has(String(txId));
+            }),
+            loading: false,
+          }));
+
+          return true;
+        } catch (err) {
+          set({ error: err.message || "Tömeges törlés hiba", loading: false });
+          throw err;
+        }
+      },
+
       resetTransactions: () =>
         set({ transactions: [], loading: false, error: null, fetched: false }),
     }),


### PR DESCRIPTION
### Motivation
- Provide a way to select and delete multiple transactions at once from the transactions list. 
- Normalize transaction identifier handling so selection and deletion works across different backend id field names.
- Improve filter UI and table styling to accommodate bulk actions and show user feedback for bulk operations.

### Description
- Added helper utilities `getTransactionId` and `normalizeTransactionId` and unified ID handling when rendering rows and checkboxes.
- Implemented bulk-delete UI state and controls in `Transactions.jsx` including `bulkDeleteMode`, selection toggles, a bulk delete confirmation flow, and inline error messages; key handlers include `toggleBulkDeleteMode`, `toggleTransactionSelection`, `handleBulkDelete`, and `cancelBulkDelete`.
- Added a store action `massDeleteTransactions` in `useTransaction.js` which calls `/api/transactions/mass_delete` with selected ids, updates local state on success, and handles errors/loading state.
- Updated markup to show a selection column when bulk-delete mode is active and use stable `key` values for rows; improved filter apply/clear logic and active filter display.
- Extended and cleaned up `Transactions.css` with styles for bulk-delete buttons, error messages, filter controls, and responsive tweaks.

### Testing
- No new automated tests were added for this change; I ran the existing test suite via `npm test` and the pre-existing tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a599a876d08328982b04d0bf0517b4)