### PR TITLE
Refactor transactions loading state into reusable Loading component

### DIFF
--- a/src/components/Loading.jsx
+++ b/src/components/Loading.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+import "./styles/Loading.css";
+
+export default function Loading({ label = "Betöltés...", className = "" }) {
+  return (
+    <div className={`loadingContainer ${className}`.trim()} role="status" aria-live="polite">
+      <span className="loadingSpinner" aria-hidden="true" />
+      <p className="loadingText">{label}</p>
+    </div>
+  );
+}

--- a/src/components/styles/Loading.css
+++ b/src/components/styles/Loading.css
@@ -1,0 +1,30 @@
+.loadingContainer {
+  min-height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 0.75rem;
+  color: var(--text-primary);
+}
+
+.loadingSpinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 9999px;
+  border: 3px solid rgba(99, 102, 241, 0.2);
+  border-top-color: var(--accent-primary);
+  animation: loadingSpin 0.8s linear infinite;
+}
+
+.loadingText {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+@keyframes loadingSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -4,6 +4,7 @@ import { useTransaction } from "../stores/useTransaction";
 import { useUser } from "../stores/useUser";
 import "./styles/Transactions.css";
 import MassImportModal from "../components/Modals/MassImportModal.jsx";
+import Loading from "../components/Loading";
 
 const extractTransactionId = (tx) => {
   const raw = tx?.id ?? tx?.transaction_id ?? tx?.tran_id ?? tx?._id ?? tx?.path ?? tx?.ref_path ?? null;
@@ -153,7 +154,7 @@ export default function Transactions() {
     }
   };
 
-  if (loading) return <div>Betöltés...</div>;
+  if (loading) return <Loading />;
 
   if (!transactions || transactions.length === 0)
     return (


### PR DESCRIPTION
### Motivation
- A centralizált, újrahasznosítható betöltés UI létrehozása a separation of concerns és a clean code elvek betartására.
- A jelenlegi egyszerű szöveges fallback (`"Betöltés..."`) lecserélése egy vizuálisan egységes és könnyen újrafelhasználható komponensre.
- Későbbi bővítések és konzisztens megjelenés megkönnyítése az alkalmazás több pontján.

### Description
- Hozzáadtam egy új `Loading` komponenst `src/components/Loading.jsx` fájlban, ami fogad egy opcionális `label` és `className` prop-ot.
- Létrehoztam a komponenshez tartozó stílusfájlt `src/components/styles/Loading.css`, amely tartalmaz egy animált spinner-t és a középre rendezett szöveget.
- A `Transactions` oldalon kicseréltem az inline `"Betöltés..."` fallback-ot az új `Loading` komponensre (`if (loading) return <Loading />;`).

### Testing
- Futott `npm ci` és a függőségek telepítése sikeres volt.
- Futott `npm run build` és a termelési build befejeződött sikeresen (a meglévő, nem kapcsolódó Vite/CSS warningok megjelentek, de nem hibáztatták a buildet).
- Lokálisan elindított `npm run dev` és a felületet leellenőriztem képernyőképekkel a futó szerverről, amelyek sikeresen készültek.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5bac24bd483288cde2d43a4220952)